### PR TITLE
Switch from kuio to ioplus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,11 @@ add_executable(forcelang
 
 target_link_libraries(forcelang
   taihen_stub
-  kuio_stub
   SceLibc_stub
   SceAppMgr_stub
   SceAppUtil_stub
+  SceIofilemgr_stub
+  SceLibKernel_stub
 )
 
 set_target_properties(forcelang

--- a/README.md
+++ b/README.md
@@ -7,14 +7,17 @@ Requirements
 ------------
 
 * A way to use taiHEN plugins (developed using a PS Vita on 3.65 Enso)
-* [kuio](https://github.com/Rinnegatamante/kuio) (for config file access; not sure if this dependency can be removed?)
+* [ioplus](https://github.com/CelesteBlue-dev/PSVita-RE-tools/tree/master/ioPlus/ioPlus-0.1/release) (for config file access)
 
 Installation
 ------------
 
-Copy `forcelang.suprx` to `ur0:/tai`, then add the plugin to the `config.txt` section of each application you want to use it with.
+Copy `forcelang.suprx` and `ioplus.skprx` to `ur0:/tai`, then add the plugin to the `config.txt` section of each application you want to use it with.
 
 ```
+*KERNEL
+ur0:tai/ioplus.skprx
+
 # Example for Digimon Story: Cyber Sleuth (European PSN)
 *PCSB00861
 ur0:tai/forcelang.suprx

--- a/forcelang.c
+++ b/forcelang.c
@@ -9,10 +9,10 @@
 
 #include <psp2/kernel/modulemgr.h>
 #include <psp2/io/fcntl.h>
+#include <psp2/io/stat.h>
 #include <psp2/appmgr.h>
 #include <psp2/system_param.h>
 
-#include <kuio.h>
 #include <taihen.h>
 
 #define DATA_DIRECTORY "ur0:/data/forcelang"
@@ -57,12 +57,11 @@ void fetchInformation()
 
 void test()
 {
-    SceUID fd;
-    kuIoOpen(DATA_DIRECTORY "/test.txt", SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, &fd);
+    SceUID fd = sceIoOpen(DATA_DIRECTORY "/test.txt", SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, 0777);
     if(fd >= 0)
     {
-        kuIoWrite(fd, appTitleId, sizeof(char) * 12);
-        kuIoClose(fd);
+        sceIoWrite(fd, appTitleId, sizeof(char) * 12);
+        sceIoClose(fd);
     }
 }
 
@@ -73,31 +72,31 @@ void readConfig()
     memset(buffer, 0, 128);
 
     // Try to open config file, also create directory if necessary
-    kuIoMkdir(DATA_DIRECTORY);
-    SceUID fd;
+    sceIoMkdir(DATA_DIRECTORY, 0777);
+
     filename = malloc(sizeof(char) * 128);
     sprintf(filename, DATA_DIRECTORY "/%s.txt", appTitleId);
-    kuIoOpen(filename, SCE_O_RDONLY, &fd);
+    SceUID fd = sceIoOpen(filename, SCE_O_RDONLY, 0777);
 
     if (fd >= 0)
     {
         // Config file exists, read the value
-        kuIoRead(fd, buffer, 128);
-        kuIoClose(fd);
+        sceIoRead(fd, buffer, 128);
+        sceIoClose(fd);
 
         sscanf(buffer, "%d", &language);
     }
     else
     {
         // Config file doesn't exist, try to create it
-        kuIoOpen(filename, SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, &fd);
+        fd = sceIoOpen(filename, SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, 0777);
         if (fd >= 0)
         {
             // Config file created, write the system language as default
             sprintf(buffer, "%d", language);
 
-            kuIoWrite(fd, buffer, sizeof(char));
-            kuIoClose(fd);
+            sceIoWrite(fd, buffer, sizeof(char));
+            sceIoClose(fd);
         }
     }
 }


### PR DESCRIPTION
It seems the "modern" way to get permissions to access the complete filesystem is ioplus (and I already had it installed for iTLS), so this switches from kuio to that.

Built & tested as working (on 3.60 with Enso) :D
